### PR TITLE
Model evaluation fix

### DIFF
--- a/03_model_evaluation/model-evaluation-processing-job.ipynb
+++ b/03_model_evaluation/model-evaluation-processing-job.ipynb
@@ -393,13 +393,6 @@
     "from IPython import display\n",
     "display.Image(\"confusion_matrix.png\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
**Background**: Testing SageMaker Immersion day content on workshop studio, since last time we run the immersion day was using Event Engine.

**Issue**: While creating your own container in module 3: [model-evaluation-processing-job.ipynb](https://github.com/absynthe/end-to-end-workshop-for-computer-vision/blob/main/03_model_evaluation/model-evaluation-processing-job.ipynb) the following error occur:

**Error**:
```
Traceback (most recent call last):
  File "/opt/conda/bin/sm-docker", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_studio_image_build/cli.py", line 133, in main
    args.func(args, unknown)
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_studio_image_build/cli.py", line 73, in build_image
    builder.build_image(
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_studio_image_build/builder.py", line 72, in build_image
    with TempCodeBuildProject(f"{bucket}/{key}", role, repository=repository, 
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_studio_image_build/codebuild.py", line 82, in __enter__
    client.create_project(**args)
  File "/opt/conda/lib/python3.8/site-packages/botocore/client.py", line 535, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/opt/conda/lib/python3.8/site-packages/botocore/client.py", line 980, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the CreateProject operation: User: arn:aws:sts::606392063844:assumed-role/cfnstudiodomain-SageMakerExecutionRole-U6er23lIOE8Q/SageMaker is not authorized to perform: iam:PassRole on resource: arn:aws:iam::606392063844:role/cfnstudiodomain-SageMakerExecutionRole-U6er23lIOE8Q because no identity-based policy allows the iam:PassRole action
```

**Resolution**:
Given that we are not the owner of the content ([Amazon SageMaker Immersion Day ](https://studio.us-east-1.prod.workshops.aws/workshops/public/63069e26-921c-4ce1-9cc7-dd882ff62575), we need to include the steps on how to add trust policy to the SageMaker execution IAM role for AWS CodeBuild.
